### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const util = require('reshape-plugin-util')
 
 module.exports = function yellPlugin (tree) {
   return util.modifyNodes(tree, (node) => node.name === 'p', (node) => {
-    node.content = node.content.map((n) => n.content.toUpperCase())
+    node.content = node.content.map((n) => Object.assign(n, { content: n.content.toUpperCase() }))
     return node
   })
 }


### PR DESCRIPTION
Currently, if you run the example you get the following error:
```
Potentially unhandled rejection [1] Error: Unrecognized node type: undefined
Node: "HELLO WORLD"
```

This is because you override the object `{ type: 'text', content: 'Hello world', location: ... }` with the string `HELLO WORLD`. 

This PR reassigns the `content` instead of overriding the object.
